### PR TITLE
enabling mvn java:exec for the project

### DIFF
--- a/TheGame/pom.xml
+++ b/TheGame/pom.xml
@@ -7,6 +7,11 @@
   <version>1.0-SNAPSHOT</version>
   <name>TheGame</name>
   <url>http://maven.apache.org</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
@@ -15,4 +20,28 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.0.2</version>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>1.6.0</version>
+        <configuration>
+          <mainClass>com.mycompany.app.App</mainClass>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
This Pull Requests changes the maven configuration so that we can use 

mvn java:exec 
instead of 
java -cp target/TheGame-1.0-SNAPSHOT.jar com.mycompany.app.App

Resolves issue #3 
